### PR TITLE
Sys.inspect support

### DIFF
--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -61,7 +61,7 @@ Changelog:
  - initial release
 **/
 
-var sys = require('sys');
+var util = require('util');
 
 var sprintf = (function() {
 	function get_type(variable) {
@@ -113,7 +113,7 @@ var sprintf = (function() {
 					case 'd': arg = parseInt(arg, 10); break;
 					case 'e': arg = match[7] ? arg.toExponential(match[7]) : arg.toExponential(); break;
 					case 'f': arg = match[7] ? parseFloat(arg).toFixed(match[7]) : parseFloat(arg); break;
-					case 'O': arg = sys.inspect(arg); break;
+					case 'O': arg = util.inspect(arg); break;
 					case 'o': arg = arg.toString(8); break;
 					case 's': arg = ((arg = String(arg)) && match[7] ? arg.substring(0, match[7]) : arg); break;
 					case 'u': arg = Math.abs(arg); break;

--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -61,6 +61,8 @@ Changelog:
  - initial release
 **/
 
+var sys = require('sys');
+
 var sprintf = (function() {
 	function get_type(variable) {
 		return Object.prototype.toString.call(variable).slice(8, -1).toLowerCase();
@@ -102,7 +104,7 @@ var sprintf = (function() {
 					arg = argv[cursor++];
 				}
 
-				if (/[^s]/.test(match[8]) && (get_type(arg) != 'number')) {
+				if (/[^sO]/.test(match[8]) && (get_type(arg) != 'number')) {
 					throw(sprintf('[sprintf] expecting number but found %s', get_type(arg)));
 				}
 				switch (match[8]) {
@@ -111,6 +113,7 @@ var sprintf = (function() {
 					case 'd': arg = parseInt(arg, 10); break;
 					case 'e': arg = match[7] ? arg.toExponential(match[7]) : arg.toExponential(); break;
 					case 'f': arg = match[7] ? parseFloat(arg).toFixed(match[7]) : parseFloat(arg); break;
+					case 'O': arg = sys.inspect(arg); break;
 					case 'o': arg = arg.toString(8); break;
 					case 's': arg = ((arg = String(arg)) && match[7] ? arg.substring(0, match[7]) : arg); break;
 					case 'u': arg = Math.abs(arg); break;
@@ -138,7 +141,7 @@ var sprintf = (function() {
 			else if ((match = /^\x25{2}/.exec(_fmt)) !== null) {
 				parse_tree.push('%');
 			}
-			else if ((match = /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-fosuxX])/.exec(_fmt)) !== null) {
+			else if ((match = /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-fosOuxX])/.exec(_fmt)) !== null) {
 				if (match[2]) {
 					arg_names |= 1;
 					var field_list = [], replacement_field = match[2], field_match = [];


### PR DESCRIPTION
New format specifier 'O' for printing objects with sys.inspect

Examples:

```
> p = require('./node-sprintf').sprintf
```

Plain string

```
> p('This is %O', 'cat')
'This is \'cat\''
> p('This is %s', 'cat')
'This is cat'
```

Array

```
> p('This is %O', [1,2,3,4])
'This is [ 1, 2, 3, 4 ]'
> p('This is %s', [1,2,3,4])
'This is 1,2,3,4'
```

Object

```
> p('This is %O', {a: 10, b: 'cat'})
'This is { a: 10, b: \'cat\' }'
> p('This is %s', {a: 10, b: 'cat'})
'This is [object Object]'
> console.log({a: 10, b: 'cat'})
{ a: 10, b: 'cat' }
> console.log(p('This is %s', {a: 10, b: 'cat'}))
This is [object Object]
> console.log(p('This is %O', {a: 10, b: 'cat'}))
This is { a: 10, b: 'cat' }
```
