### PR TITLE
Object printing and error stack traces

### DIFF
--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -127,7 +127,7 @@ var sprintf = (function() {
 					arg = argv[cursor];
 					for (k = 0; k < match[2].length; k++) {
 						if (!arg.hasOwnProperty(match[2][k])) {
-							throw(sprintf('[sprintf] property "%s" does not exist', match[2][k]));
+							throw new Error(sprintf('[sprintf] property "%s" does not exist', match[2][k]));
 						}
 						arg = arg[match[2][k]];
 					}
@@ -140,7 +140,7 @@ var sprintf = (function() {
 				}
 
 				if (/[^sO]/.test(match[8]) && (get_type(arg) != 'number')) {
-					throw(sprintf('[sprintf] expecting number but found %s', get_type(arg)));
+					throw new Error(sprintf('[sprintf] expecting number but found %s', get_type(arg)));
 				}
 				switch (match[8]) {
 					case 'b': arg = arg.toString(2); break;
@@ -190,12 +190,12 @@ var sprintf = (function() {
 								field_list.push(field_match[1]);
 							}
 							else {
-								throw('[sprintf] ' + replacement_field);
+								throw new Error('[sprintf] ' + replacement_field);
 							}
 						}
 					}
 					else {
-                        throw('[sprintf] ' + replacement_field);
+                        throw new Error('[sprintf] ' + replacement_field);
 					}
 					match[2] = field_list;
 				}
@@ -203,12 +203,12 @@ var sprintf = (function() {
 					arg_names |= 2;
 				}
 				if (arg_names === 3) {
-					throw('[sprintf] mixing positional and named placeholders is not (yet) supported');
+					throw new Error('[sprintf] mixing positional and named placeholders is not (yet) supported');
 				}
 				parse_tree.push(match);
 			}
 			else {
-				throw('[sprintf] ' + _fmt);
+				throw new Error('[sprintf] ' + _fmt);
 			}
 			_fmt = _fmt.substring(match[0].length);
 		}

--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -87,22 +87,29 @@ var sprintf = (function() {
 	//    l = []
 	//    l[4] = 1
 	// Would be printed as "[1]" instead of "[, , , , 1]"
-	//
+	// 
 	str_format.object_stringify = function(obj) {
 		var str = '';
-		if (obj != null && typeof(obj) == 'object') {
-			if (obj.length != null) { //array
-				str += '[';
-				var arr = []
-				for (var i in obj) arr.push(str_format.object_stringify(obj[i]))
-				str += arr.join(', ') + ']';
-			} else { // object
-				str += '{';
-				var arr = []
-				for (var k in obj) { if(obj.hasOwnProperty(k)) arr.push(k +': ' +str_format.object_stringify(obj[k])) }
-				str += arr.join(', ') + '}';
+		if (obj != null) {
+			switch( typeof(obj) ) {
+			case 'object':
+				if (obj.length != null) { //array
+					str += '[ ';
+					var arr = []
+					for (var i in obj) arr.push(str_format.object_stringify(obj[i]))
+					str += arr.join(', ') + ' ]';
+				} else { // object
+					str += '{ ';
+					var arr = []
+					for (var k in obj) { if(obj.hasOwnProperty(k)) arr.push(k +': ' +str_format.object_stringify(obj[k])) }
+					str += arr.join(', ') + ' }';
+				}
+				return str;
+				break;
+			case 'string':				
+				return '"' + obj + '"';
+				break
 			}
-			return str;
 		}
 		return '' + obj;
 	}

--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -98,6 +98,8 @@ var sprintf = (function() {
 					var arr = []
 					for (var i in obj) arr.push(str_format.object_stringify(obj[i]))
 					str += arr.join(', ') + ' ]';
+				} else if ('getMonth' in obj) { // date
+					return 'Date(' + obj + ')';
 				} else { // object
 					str += '{ ';
 					var arr = []

--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -79,6 +79,34 @@ var sprintf = (function() {
 		return str_format.format.call(null, str_format.cache[arguments[0]], arguments);
 	};
 
+	// convert object to simple one line string without indentation or
+	// newlines. Note that this implementation does not print array
+	// values to their actual place for sparse arrays. 
+	//
+	// For example sparse array like this
+	//    l = []
+	//    l[4] = 1
+	// Would be printed as "[1]" instead of "[, , , , 1]"
+	//
+	str_format.object_stringify = function(obj) {
+		var str = '';
+		if (obj != null && typeof(obj) == 'object') {
+			if (obj.length != null) { //array
+				str += '[';
+				var arr = []
+				for (var i in obj) arr.push(str_format.object_stringify(obj[i]))
+				str += arr.join(', ') + ']';
+			} else { // object
+				str += '{';
+				var arr = []
+				for (var k in obj) { arr.push(k +': ' +str_format.object_stringify(obj[k])) }
+				str += arr.join(', ') + '}';
+			}
+			return str;
+		}
+		return '' + obj;
+	}
+
 	str_format.format = function(parse_tree, argv) {
 		var cursor = 1, tree_length = parse_tree.length, node_type = '', arg, output = [], i, k, match, pad, pad_character, pad_length;
 		for (i = 0; i < tree_length; i++) {
@@ -113,7 +141,7 @@ var sprintf = (function() {
 					case 'd': arg = parseInt(arg, 10); break;
 					case 'e': arg = match[7] ? arg.toExponential(match[7]) : arg.toExponential(); break;
 					case 'f': arg = match[7] ? parseFloat(arg).toFixed(match[7]) : parseFloat(arg); break;
-					case 'O': arg = util.inspect(arg); break;
+					case 'O': arg = str_format.object_stringify(arg); break;
 					case 'o': arg = arg.toString(8); break;
 					case 's': arg = ((arg = String(arg)) && match[7] ? arg.substring(0, match[7]) : arg); break;
 					case 'u': arg = Math.abs(arg); break;
@@ -155,12 +183,12 @@ var sprintf = (function() {
 								field_list.push(field_match[1]);
 							}
 							else {
-								throw('[sprintf] huh?');
+								throw('[sprintf] ' + replacement_field);
 							}
 						}
 					}
 					else {
-						throw('[sprintf] huh?');
+                        throw('[sprintf] ' + replacement_field);
 					}
 					match[2] = field_list;
 				}
@@ -173,7 +201,7 @@ var sprintf = (function() {
 				parse_tree.push(match);
 			}
 			else {
-				throw('[sprintf] huh?');
+				throw('[sprintf] ' + _fmt);
 			}
 			_fmt = _fmt.substring(match[0].length);
 		}

--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -99,7 +99,7 @@ var sprintf = (function() {
 			} else { // object
 				str += '{';
 				var arr = []
-				for (var k in obj) { arr.push(k +': ' +str_format.object_stringify(obj[k])) }
+				for (var k in obj) { if(obj.hasOwnProperty(k)) arr.push(k +': ' +str_format.object_stringify(obj[k])) }
 				str += arr.join(', ') + '}';
 			}
 			return str;

--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -88,23 +88,42 @@ var sprintf = (function() {
 	//    l[4] = 1
 	// Would be printed as "[1]" instead of "[, , , , 1]"
 	// 
-	str_format.object_stringify = function(obj) {
+	// If argument 'seen' is not null and array the function will check for 
+	// circular object references from argument.
+	str_format.object_stringify = function(obj, seen, depth, maxdepth) {
 		var str = '';
 		if (obj != null) {
 			switch( typeof(obj) ) {
+			case 'function': 
+				return '[Function' + (obj.name ? ': '+obj.name : '') + ']';
+			    break;
 			case 'object':
+				if (depth >= maxdepth) return '[Object]'
+				if (seen) {
+					// add object to seen list
+					seen = seen.slice(0)
+					seen.push(obj);
+				}
 				if (obj.length != null) { //array
-					str += '[ ';
+					str += '[';
 					var arr = []
-					for (var i in obj) arr.push(str_format.object_stringify(obj[i]))
-					str += arr.join(', ') + ' ]';
+					for (var i in obj) {
+						if (seen && seen.indexOf(obj[i]) >= 0) arr.push('[Circular]');
+						else arr.push(str_format.object_stringify(obj[i], seen, depth+1, maxdepth));
+					}
+					str += arr.join(', ') + ']';
 				} else if ('getMonth' in obj) { // date
 					return 'Date(' + obj + ')';
 				} else { // object
-					str += '{ ';
+					str += '{';
 					var arr = []
-					for (var k in obj) { if(obj.hasOwnProperty(k)) arr.push(k +': ' +str_format.object_stringify(obj[k])) }
-					str += arr.join(', ') + ' }';
+					for (var k in obj) { 
+						if(obj.hasOwnProperty(k)) {
+							if (seen && seen.indexOf(obj[k]) >= 0) arr.push(k + ': [Circular]');
+							else arr.push(k +': ' +str_format.object_stringify(obj[k], seen, depth+1, maxdepth)); 
+						}
+					}
+					str += arr.join(', ') + '}';
 				}
 				return str;
 				break;
@@ -150,7 +169,7 @@ var sprintf = (function() {
 					case 'd': arg = parseInt(arg, 10); break;
 					case 'e': arg = match[7] ? arg.toExponential(match[7]) : arg.toExponential(); break;
 					case 'f': arg = match[7] ? parseFloat(arg).toFixed(match[7]) : parseFloat(arg); break;
-					case 'O': arg = str_format.object_stringify(arg); break;
+				    case 'O': arg = str_format.object_stringify(arg, [], 0, parseInt(match[7]) || 5); break;
 					case 'o': arg = arg.toString(8); break;
 					case 's': arg = ((arg = String(arg)) && match[7] ? arg.substring(0, match[7]) : arg); break;
 					case 'u': arg = Math.abs(arg); break;

--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -90,7 +90,7 @@ var sprintf = (function() {
 	// 
 	// If argument 'seen' is not null and array the function will check for 
 	// circular object references from argument.
-	str_format.object_stringify = function(obj, seen, depth, maxdepth) {
+	str_format.object_stringify = function(obj, depth, maxdepth, seen) {
 		var str = '';
 		if (obj != null) {
 			switch( typeof(obj) ) {
@@ -109,7 +109,7 @@ var sprintf = (function() {
 					var arr = []
 					for (var i in obj) {
 						if (seen && seen.indexOf(obj[i]) >= 0) arr.push('[Circular]');
-						else arr.push(str_format.object_stringify(obj[i], seen, depth+1, maxdepth));
+						else arr.push(str_format.object_stringify(obj[i], depth+1, maxdepth, seen));
 					}
 					str += arr.join(', ') + ']';
 				} else if ('getMonth' in obj) { // date
@@ -120,7 +120,7 @@ var sprintf = (function() {
 					for (var k in obj) { 
 						if(obj.hasOwnProperty(k)) {
 							if (seen && seen.indexOf(obj[k]) >= 0) arr.push(k + ': [Circular]');
-							else arr.push(k +': ' +str_format.object_stringify(obj[k], seen, depth+1, maxdepth)); 
+							else arr.push(k +': ' +str_format.object_stringify(obj[k], depth+1, maxdepth, seen)); 
 						}
 					}
 					str += arr.join(', ') + '}';
@@ -169,7 +169,7 @@ var sprintf = (function() {
 					case 'd': arg = parseInt(arg, 10); break;
 					case 'e': arg = match[7] ? arg.toExponential(match[7]) : arg.toExponential(); break;
 					case 'f': arg = match[7] ? parseFloat(arg).toFixed(match[7]) : parseFloat(arg); break;
-				    case 'O': arg = str_format.object_stringify(arg, [], 0, parseInt(match[7]) || 5); break;
+				    case 'O': arg = str_format.object_stringify(arg, 0, parseInt(match[7]) || 5); break;
 					case 'o': arg = arg.toString(8); break;
 					case 's': arg = ((arg = String(arg)) && match[7] ? arg.substring(0, match[7]) : arg); break;
 					case 'u': arg = Math.abs(arg); break;


### PR DESCRIPTION
Old version used sys.inspect to print out objects for %O format, that does not work well with node 0.6 that changed the way objects are printed. 

This patch has internal object printout function that does not change with Node versions. Also, I changed exceptions to Errors so it's possible to get some stack trace where error happened.
