### PR TITLE
Simple error reporting fix

### DIFF
--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -161,7 +161,7 @@ var sprintf = (function() {
 				}
 
 				if (/[^sO]/.test(match[8]) && (get_type(arg) != 'number')) {
-					throw new Error(sprintf('[sprintf] expecting number but found %s', get_type(arg)));
+					throw new Error(sprintf('[sprintf] expecting number but found %s "' + arg + '"', get_type(arg)));
 				}
 				switch (match[8]) {
 					case 'b': arg = arg.toString(2); break;


### PR DESCRIPTION
Prints offending value when format and data do not match
