### PR TITLE
Export `sprintf()` directly

### DIFF
--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -244,5 +244,6 @@ var vsprintf = function(fmt, argv) {
 	return sprintf.apply(null, argv);
 };
 
+module.exports = sprintf;
 exports.sprintf = sprintf;
 exports.vsprintf = vsprintf;

--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -245,5 +245,5 @@ var vsprintf = function(fmt, argv) {
 };
 
 module.exports = sprintf;
-exports.sprintf = sprintf;
-exports.vsprintf = vsprintf;
+sprintf.sprintf = sprintf;
+sprintf.vsprintf = vsprintf;

--- a/test/function-export.js
+++ b/test/function-export.js
@@ -1,0 +1,5 @@
+var sprintf = require(__dirname + '/..');
+
+sprintf('Hallo %s!', 'Welt');
+sprintf.sprintf('Hallo %s!', 'Welt');
+sprintf.vsprintf('Hallo %s!', ['Welt']);

--- a/test/function-export.js
+++ b/test/function-export.js
@@ -1,5 +1,9 @@
 var sprintf = require(__dirname + '/..');
 
-sprintf('Hallo %s!', 'Welt');
-sprintf.sprintf('Hallo %s!', 'Welt');
-sprintf.vsprintf('Hallo %s!', ['Welt']);
+exports['sprintf() export works'] = function(test) {
+	test.equal(sprintf('Hallo %s!', 'Welt'), 'Hallo Welt!');
+	test.equal(sprintf.sprintf('Hallo %s!', 'Welt'), 'Hallo Welt!');
+	test.equal(sprintf.vsprintf('Hallo %s!', ['Welt']), 'Hallo Welt!');
+
+	test.done();
+};


### PR DESCRIPTION
Make `require('sprintf')` return a function to enable direct usage like:

```
var sprintf = require('sprintf');
sprintf('Hallo %i. $Welt!', 1);
```
