### PR TITLE
Special handling for printing out Error object

### DIFF
--- a/lib/sprintf.js
+++ b/lib/sprintf.js
@@ -98,6 +98,7 @@ var sprintf = (function() {
 				return '[Function' + (obj.name ? ': '+obj.name : '') + ']';
 			    break;
 			case 'object':
+				if ( obj instanceof Error) { return '[' + obj.toString() + ']' };
 				if (depth >= maxdepth) return '[Object]'
 				if (seen) {
 					// add object to seen list


### PR DESCRIPTION
Node.js Error objects have their own special toString output. Use that instead of trying to process it as objects.
