### PR TITLE
Tweaked in a few Node.js conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
     "repository": {
         "type": "git",  
         "url": "https://github.com/maritz/node-sprintf.git"
+    },
+    "scripts": {
+        "test": "nodeunit test/function-export.js"
+    },
+    "devDependencies": {
+        "nodeunit": "0.8.0"
     }
 }
 


### PR DESCRIPTION
Thanks for uploading your awsome sprintf package to NPM, I love `sprintf()`!

I took the liberty of adding `node_modules/` to `.gitignore` so that git doesn't try to version control sprintf's dependencies.

I also configured `package.json` for nodeunit, so all you have to do to test node-sprintf is download the source and run `npm install && npm test`.
